### PR TITLE
fix nil ptr value panic

### DIFF
--- a/values/value.go
+++ b/values/value.go
@@ -54,6 +54,9 @@ func ValueOf(value interface{}) Value { // nolint: gocyclo
 	switch reflect.TypeOf(value).Kind() {
 	case reflect.Ptr:
 		rv := reflect.ValueOf(value)
+		if rv.IsNil() {
+			return nilValue
+		}
 		if rv.Type().Elem().Kind() == reflect.Struct {
 			return structValue{wrapperValue{value}}
 		}

--- a/values/value_test.go
+++ b/values/value_test.go
@@ -17,6 +17,13 @@ func TestValue_Interface(t *testing.T) {
 	require.Equal(t, 123, iv.Interface())
 }
 
+func TestValueNilPointer(t *testing.T) {
+	nv := ValueOf(func() *int {
+		return nil
+	}())
+	require.Nil(t, nv.Interface())
+}
+
 func TestValue_Equal(t *testing.T) {
 	iv := ValueOf(123)
 	require.True(t, iv.Equal(ValueOf(123)))


### PR DESCRIPTION
Fix panic "reflect: call of reflect.Value.Interface on zero Value" that occurred while executing a template with a structure that contains a pointer field with nil reference.